### PR TITLE
Add linting/checkstyle for Java. 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.checkstyle.configuration": "/google_checks.xml"
+}

--- a/linting-instructions.md
+++ b/linting-instructions.md
@@ -1,0 +1,25 @@
+# Linting Java Code in VSCode
+
+This adds linting to java files using Google's default checkstyle/code style.
+
+## Install
+
+Install https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle extension to VScode.
+
+## Usage
+
+On files you wish to style check.
+
+1. Ctrl+Shift+P (Action quick switcher)
+2. Checkstyle: Check COde with Checkstyle)
+
+# Errors
+
+### JDK not found Error
+
+If Checkstyle cannot find your installed JDK ensure you have your $JAVA_HOME environment variable set.
+
+Follow [these instructions](https://javatutorial.net/set-java-home-windows-10) to set your JAVA_HOME environment variable on Windows 10.
+
+After close and re-open VSCode to load the new environment variables.
+

--- a/linting-instructions.md
+++ b/linting-instructions.md
@@ -11,7 +11,7 @@ Install https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-che
 On files you wish to style check.
 
 1. Ctrl+Shift+P (Action quick switcher)
-2. Checkstyle: Check COde with Checkstyle)
+2. Select the "Checkstyle: Check Code with Checkstyle" option.
 
 # Errors
 


### PR DESCRIPTION
The main file now has lint errors that can be fixed by students. 

@Team1710CTO @14352 

Check and see if this works for you. See linting-instructions.md for how to set up.

Does not need to get merged... but so you know how to do it - I can help you set this up if you have trouble lmk.
